### PR TITLE
add `compileOnly` for gson library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,15 @@ repositories {
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.0")
-    implementation("com.google.code.gson:gson:2.12.1")
+    compileOnly("com.google.code.gson:gson:2.12.1")
     implementation("org.bstats:bstats-bukkit:3.0.0")
 }
 
 tasks {
     shadowJar {
+        minimize()
+        relocate("org.bstats", "com.piotrbednarski.bstats")
         archiveClassifier.set("")
-        relocate("org.bstats", "com.grinderwolf.swm.internal.bstats")
     }
 
     assemble {


### PR DESCRIPTION
This pull request addresses the issue of increased JAR size after adding the `shadowJar` plugin by changing the Gson dependency to `compileOnly`. This change ensures that Gson is available during compilation but is not included in the final JAR, thus reducing the overall size.