### PR TITLE
Migrate to PaperMC and Update Dependencies/Package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id("com.gradleup.shadow") version "8.3.5"
+    id("com.gradleup.shadow") version "9.0.0-beta8"
 }
 
 group = 'com.piotrbednarski'

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ plugins {
     id("com.gradleup.shadow") version "9.0.0-beta8"
 }
 
-group = 'com.piotrbednarski'
-version = '1.1.6'
+group = 'pl.bednarskiwsieci'
+version = '1.1.7'
 
 repositories {
     mavenCentral()
     maven {
-        name = "spigotmc-repo"
-        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        name = 'papermc'
+        url = 'https://repo.papermc.io/repository/maven-public/'
     }
     maven {
         name = "sonatype"
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.0")
     compileOnly("com.google.code.gson:gson:2.12.1")
     implementation("org.bstats:bstats-bukkit:3.0.0")
@@ -32,7 +32,7 @@ dependencies {
 tasks {
     shadowJar {
         minimize()
-        relocate("org.bstats", "com.piotrbednarski.bstats")
+        relocate("org.bstats", "pl.bednarskiwsieci.bstats")
         archiveClassifier.set("")
     }
 

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
@@ -1,14 +1,14 @@
-package com.piotrbednarski.logicgatesplugin;
+package pl.bednarskiwsieci.logicgatesplugin;
 
-import com.piotrbednarski.logicgatesplugin.commands.LogicGatesCommand;
-import com.piotrbednarski.logicgatesplugin.integrations.WorldEditIntegration;
-import com.piotrbednarski.logicgatesplugin.listeners.GateListener;
-import com.piotrbednarski.logicgatesplugin.model.GateData;
-import com.piotrbednarski.logicgatesplugin.model.GateType;
-import com.piotrbednarski.logicgatesplugin.util.ConfigManager;
-import com.piotrbednarski.logicgatesplugin.util.GateUtils;
-import com.piotrbednarski.logicgatesplugin.util.GatesConfigManager;
-import com.piotrbednarski.logicgatesplugin.util.UpdateChecker;
+import pl.bednarskiwsieci.logicgatesplugin.commands.LogicGatesCommand;
+import pl.bednarskiwsieci.logicgatesplugin.integrations.WorldEditIntegration;
+import pl.bednarskiwsieci.logicgatesplugin.listeners.GateListener;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
+import pl.bednarskiwsieci.logicgatesplugin.util.ConfigManager;
+import pl.bednarskiwsieci.logicgatesplugin.util.GateUtils;
+import pl.bednarskiwsieci.logicgatesplugin.util.GatesConfigManager;
+import pl.bednarskiwsieci.logicgatesplugin.util.UpdateChecker;
 import com.sk89q.worldedit.WorldEdit;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
@@ -33,7 +33,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.piotrbednarski.logicgatesplugin.listeners.GateListener.ROTATION_ORDER;
+import static pl.bednarskiwsieci.logicgatesplugin.listeners.GateListener.ROTATION_ORDER;
 
 /// Main plugin class for Logic Gates implementation in Minecraft.
 /// Handles gate management, configuration, and event processing.

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/commands/LogicGatesCommand.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/commands/LogicGatesCommand.java
@@ -1,9 +1,9 @@
-package com.piotrbednarski.logicgatesplugin.commands;
+package pl.bednarskiwsieci.logicgatesplugin.commands;
 
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
-import com.piotrbednarski.logicgatesplugin.model.GateType;
-import com.piotrbednarski.logicgatesplugin.util.ConfigManager;
-import com.piotrbednarski.logicgatesplugin.util.UpdateChecker;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
+import pl.bednarskiwsieci.logicgatesplugin.util.ConfigManager;
+import pl.bednarskiwsieci.logicgatesplugin.util.UpdateChecker;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/integrations/WorldEditIntegration.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/integrations/WorldEditIntegration.java
@@ -1,10 +1,10 @@
-package com.piotrbednarski.logicgatesplugin.integrations;
+package pl.bednarskiwsieci.logicgatesplugin.integrations;
 
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
-import com.piotrbednarski.logicgatesplugin.listeners.GateListener;
-import com.piotrbednarski.logicgatesplugin.model.GateData;
-import com.piotrbednarski.logicgatesplugin.model.GateType;
-import com.piotrbednarski.logicgatesplugin.util.GateUtils;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.listeners.GateListener;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
+import pl.bednarskiwsieci.logicgatesplugin.util.GateUtils;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.AbstractDelegateExtent;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
@@ -1,12 +1,12 @@
-package com.piotrbednarski.logicgatesplugin.listeners;
+package pl.bednarskiwsieci.logicgatesplugin.listeners;
 
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
-import com.piotrbednarski.logicgatesplugin.commands.LogicGatesCommand;
-import com.piotrbednarski.logicgatesplugin.model.GateData;
-import com.piotrbednarski.logicgatesplugin.model.GateType;
-import com.piotrbednarski.logicgatesplugin.util.ConfigManager;
-import com.piotrbednarski.logicgatesplugin.util.GateUtils;
-import com.piotrbednarski.logicgatesplugin.util.UpdateChecker;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.commands.LogicGatesCommand;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
+import pl.bednarskiwsieci.logicgatesplugin.util.ConfigManager;
+import pl.bednarskiwsieci.logicgatesplugin.util.GateUtils;
+import pl.bednarskiwsieci.logicgatesplugin.util.UpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateData.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateData.java
@@ -1,4 +1,4 @@
-package com.piotrbednarski.logicgatesplugin.model;
+package pl.bednarskiwsieci.logicgatesplugin.model;
 
 import org.bukkit.block.BlockFace;
 

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateType.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateType.java
@@ -1,4 +1,4 @@
-package com.piotrbednarski.logicgatesplugin.model;
+package pl.bednarskiwsieci.logicgatesplugin.model;
 
 public enum GateType {
     XOR, AND, OR, NOT, NAND, NOR, XNOR, IMPLICATION, RS_LATCH, TIMER

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/ConfigManager.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/ConfigManager.java
@@ -1,6 +1,6 @@
-package com.piotrbednarski.logicgatesplugin.util;
+package pl.bednarskiwsieci.logicgatesplugin.util;
 
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GateUtils.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GateUtils.java
@@ -1,8 +1,8 @@
-package com.piotrbednarski.logicgatesplugin.util;
+package pl.bednarskiwsieci.logicgatesplugin.util;
 
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
-import com.piotrbednarski.logicgatesplugin.model.GateData;
-import com.piotrbednarski.logicgatesplugin.model.GateType;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -17,7 +17,7 @@ import org.bukkit.block.data.type.Repeater;
 
 import java.util.Arrays;
 
-import static com.piotrbednarski.logicgatesplugin.listeners.GateListener.ROTATION_ORDER;
+import static pl.bednarskiwsieci.logicgatesplugin.listeners.GateListener.ROTATION_ORDER;
 
 /// Utility class for handling logic gate operations and Minecraft block interactions.
 /// Provides methods for location conversion, block rotation, logic calculations, and visual effects.

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GatesConfigManager.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GatesConfigManager.java
@@ -1,9 +1,9 @@
-package com.piotrbednarski.logicgatesplugin.util;
+package pl.bednarskiwsieci.logicgatesplugin.util;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
-import com.piotrbednarski.logicgatesplugin.model.GateData;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
 import org.bukkit.Location;
 import org.bukkit.Material;
 

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/UpdateChecker.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/UpdateChecker.java
@@ -1,11 +1,11 @@
-package com.piotrbednarski.logicgatesplugin.util;
+package pl.bednarskiwsieci.logicgatesplugin.util;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
-import com.piotrbednarski.logicgatesplugin.LogicGatesPlugin;
+import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,11 +1,11 @@
 name: LogicGates
-version: '1.1.6'
+version: ${version}
 main: com.piotrbednarski.logicgatesplugin.LogicGatesPlugin
 api-version: '1.16'
 softdepend: [ Multiverse-Core, WorldEdit, AsyncWorldEdit, FastAsyncWorldEdit ]
 authors: [ Piotr Bednarski ]
 description: Forget about giant Redstone logic gates. All logic gates in one block!
-website: https://bednarskiwsieci.pl
+website: https://logicgates.bednarskiwsieci.pl
 
 commands:
   logicgates:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: LogicGates
 version: ${version}
-main: com.piotrbednarski.logicgatesplugin.LogicGatesPlugin
+main: pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin
 api-version: '1.16'
 softdepend: [ Multiverse-Core, WorldEdit, AsyncWorldEdit, FastAsyncWorldEdit ]
 authors: [ Piotr Bednarski ]


### PR DESCRIPTION
This PR primarily migrates the project to PaperMC-API.  In addition, it includes necessary dependency updates and a package name refactoring.

Changes:

* Migrated to PaperMC-API.
* Updated `com.gradleup.shadow` to the latest version and removed the hard-coded version.
* Updated the package name to `pl.bednarskiwsieci`.