### PR TITLE
Improve documentation and add `oneTick` option

### DIFF
--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
@@ -165,6 +165,10 @@ public class LogicGatesPlugin extends JavaPlugin {
     // endregion
 
     // region Component Registration
+
+    /// Checks if the WorldEdit plugin is present on the server.
+    ///
+    /// @return true if WorldEdit is present, false otherwise
     private boolean isWorldEditPresent() {
         Plugin[] plugins = Bukkit.getPluginManager().getPlugins();
         for (Plugin plugin : plugins) {
@@ -175,6 +179,8 @@ public class LogicGatesPlugin extends JavaPlugin {
         return false;
     }
 
+    /// Registers the commands for the plugin. The main command "logicgates" is set with its executor.
+    /// Also registers the WorldEditIntegration event listener.
     private void registerCommands() {
         Objects.requireNonNull(this.getCommand("logicgates"))
                 .setExecutor(new LogicGatesCommand(this, configManager, updateChecker));
@@ -183,6 +189,7 @@ public class LogicGatesPlugin extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new WorldEditIntegration(this), this);
     }
 
+    /// Registers the event listeners for the plugin. This includes the GateListener which handles gate-related events.
     private void registerEventListeners() {
         getServer().getPluginManager().registerEvents(new GateListener(this, configManager, updateChecker), this);
     }
@@ -252,6 +259,8 @@ public class LogicGatesPlugin extends JavaPlugin {
     // endregion
 
     // region Gate management
+
+    /// Initializes the tick system to update the tick counter every server tick (50ms).
     private void initializeTickSystem() {
         // Update tick counter every server tick (50ms)
         new BukkitRunnable() {
@@ -262,6 +271,10 @@ public class LogicGatesPlugin extends JavaPlugin {
         }.runTaskTimer(this, 0L, 1L);
     }
 
+    /// Schedules updates for blocks that are dependent on the given output block and facing direction.
+    ///
+    /// @param outputBlock the block for which dependent updates are to be scheduled.
+    /// @param facing the direction the block is facing.
     private void scheduleDependentUpdates(Block outputBlock, BlockFace facing) {
         // Check all potential connection directions
         EnumSet<BlockFace> directions = EnumSet.of(
@@ -812,28 +825,56 @@ public class LogicGatesPlugin extends JavaPlugin {
         return inspectionModePlayers;
     }
 
+    /**
+     * Gets the players who are in input toggle mode.
+     *
+     * @return a set of UUIDs representing the players in input toggle mode.
+     */
     public Set<UUID> getInputToggleModePlayers() {
         return inputToggleModePlayers;
     }
 
+    /// Checks if the legacy mode is enabled.
+    ///
+    /// @return true if legacy mode is enabled, false otherwise.
     public boolean isLegacyMode() {
         return legacyMode;
     }
 
+    /// Sets the legacy mode.
+    ///
+    /// @param legacyMode true to enable legacy mode, false to disable it.
     public void setLegacyMode(boolean legacyMode) {
         this.legacyMode = legacyMode;
     }
 
+    /// Checks if the NotGateInputPosition mode is enabled.
+    ///
+    /// @return true if mode is enabled, false otherwise.
     public String getNotGateInputPosition() {
         return notGateInputPosition;
     }
 
+    /// Sets the NotGateInputPosition mode.
+    ///
+    /// @param notGateInputPosition true to enable, false to disable it.
     public void setNotGateInputPosition(String notGateInputPosition) {
         this.notGateInputPosition = notGateInputPosition;
     }
 
-    public boolean isOneTick() { return oneTick; }
-    public void setOneTick(boolean oneTick) { this.oneTick = oneTick; }
+    /// Checks if the one-tick mode is enabled.
+    ///
+    /// @return true if one-tick mode is enabled, false otherwise.
+    public boolean isOneTick() {
+        return oneTick;
+    }
+
+    /// Sets the one-tick mode.
+    ///
+    /// @param oneTick true to enable one-tick mode, false to disable it.
+    public void setOneTick(boolean oneTick) {
+        this.oneTick = oneTick;
+    }
 
     /// Checks if particle effects are enabled.
     ///
@@ -915,7 +956,10 @@ public class LogicGatesPlugin extends JavaPlugin {
         return GateUtils.convertStringToLocation(str);
     }
 
-    public void reloadConfiguration() {
+    /// Reloads the global configuration for the plugin.
+    /// This involves reloading the main configuration settings.
+    /// and reloading the gate configurations.
+    public void reloadGlobalConfiguration() {
         configManager.reloadConfiguration();
         gatesConfigManager.loadGates(gates);
     }

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/LogicGatesPlugin.java
@@ -44,7 +44,6 @@ public class LogicGatesPlugin extends JavaPlugin {
     private final ConcurrentHashMap<Location, GateData> gates = new ConcurrentHashMap<>();
     private final ConcurrentLinkedQueue<Location> gatesToUpdate = new ConcurrentLinkedQueue<>();
     private final Set<UUID> debugPlayers = new HashSet<>();
-    private final Set<UUID> rotationModePlayers = new HashSet<>();
     private final Set<UUID> inspectionModePlayers = new HashSet<>();
     private final Set<UUID> inputToggleModePlayers = new HashSet<>();
     private final Set<UUID> cooldownModePlayers = new HashSet<>();
@@ -75,6 +74,7 @@ public class LogicGatesPlugin extends JavaPlugin {
     private String defaultLang = "en";
     private boolean legacyMode = false;
     private String notGateInputPosition = "default";
+    private boolean oneTick = false;
     // endregion
 
     // region Task Management
@@ -112,7 +112,7 @@ public class LogicGatesPlugin extends JavaPlugin {
 
         // Initialize bStats
         int BSTATS_ID = 24700;
-        Metrics metrics = new Metrics(this, BSTATS_ID);
+        new Metrics(this, BSTATS_ID);
 
         // Automatic update check on startup
         try {
@@ -311,7 +311,8 @@ public class LogicGatesPlugin extends JavaPlugin {
 
         // Tick-based cooldown check (2 ticks minimum)
         Long lastTick = lastUpdateTicks.get(loc);
-        if (lastTick != null && (serverTick.get() - lastTick) < 2)
+        int ticks = isOneTick() ? 1 : 2;
+        if (lastTick != null && (serverTick.get() - lastTick) < ticks)
             return;
 
         // Store current tick before processing
@@ -524,7 +525,6 @@ public class LogicGatesPlugin extends JavaPlugin {
     private void cleanupData() {
         gates.clear();
         debugPlayers.clear();
-        rotationModePlayers.clear();
         inspectionModePlayers.clear();
     }
 
@@ -761,13 +761,6 @@ public class LogicGatesPlugin extends JavaPlugin {
         return debugPlayers;
     }
 
-    /// Returns the set of player UUIDs who are in rotation mode.
-    ///
-    /// @return the set of players in rotation mode
-    public Set<UUID> getRotationModePlayers() {
-        return rotationModePlayers;
-    }
-
     /// Returns the set of player UUIDs who are in inspection mode.
     ///
     /// @return the set of players in inspection mode
@@ -794,6 +787,9 @@ public class LogicGatesPlugin extends JavaPlugin {
     public void setNotGateInputPosition(String notGateInputPosition) {
         this.notGateInputPosition = notGateInputPosition;
     }
+
+    public boolean isOneTick() { return oneTick; }
+    public void setOneTick(boolean oneTick) { this.oneTick = oneTick; }
 
     /// Checks if particle effects are enabled.
     ///

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/commands/LogicGatesCommand.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/commands/LogicGatesCommand.java
@@ -115,6 +115,10 @@ public class LogicGatesCommand implements CommandExecutor {
         return true;
     }
 
+    /// Handles the update check command sent by the specified sender. If the sender has the required admin permissions,
+    /// an update check will be initiated, and a message will be sent to the sender indicating that the update check is in progress.
+    ///
+    /// @param sender the command sender who issued the update check command
     private void handleUpdateCheck(CommandSender sender) {
         if (!validateAdminPermission(sender)) return;
 
@@ -129,12 +133,21 @@ public class LogicGatesCommand implements CommandExecutor {
         plugin.toggleDebugMode((Player) sender);
     }
 
+    /// Handles the reload command sent by the specified sender. If the sender has the required admin permissions,
+    /// the plugin configuration will be reloaded and a confirmation message will be sent to the sender.
+    ///
+    /// @param sender the command sender who issued the reload command
     private void handleReload(CommandSender sender) {
         if (!validateAdminPermission(sender)) return;
-        plugin.reloadConfiguration();
+        plugin.reloadGlobalConfiguration();
         sender.sendMessage("LogicGates config reloaded!");
     }
 
+    /// Handles the toggle input command sent by the specified sender. If the sender is a player and has the required
+    /// permissions, the player will be added to the input toggle mode players list and a confirmation message will be sent.
+    /// If the sender is not a player, an error message will be sent.
+    ///
+    /// @param sender the command sender who issued the toggle input command
     private void handleToggleInputCommand(CommandSender sender) {
         if (!(sender instanceof Player player)) {
             sender.sendMessage(plugin.getMessage("errors.player_only"));
@@ -165,6 +178,11 @@ public class LogicGatesCommand implements CommandExecutor {
         openGateGUI(player);
     }
 
+    /// Opens the gate selection GUI for the specified player. The GUI will display all configured gate items
+    /// based on the configuration settings. If no gates are configured or the configuration section is missing,
+    /// appropriate messages will be sent to the player.
+    ///
+    /// @param player the player for whom the gate selection GUI will be opened
     private void openGateGUI(Player player) {
         ConfigurationSection carpetsSection = configManager.getConfig().getConfigurationSection("carpets");
         if (carpetsSection == null) {
@@ -210,6 +228,12 @@ public class LogicGatesCommand implements CommandExecutor {
         player.openInventory(gui);
     }
 
+    /// Creates a GUI item for the specified gate type using the given configuration section and material.
+    ///
+    /// @param itemSection the configuration section containing item settings
+    /// @param material the material of the item to be created
+    /// @param type the type of the gate to be associated with the item
+    /// @return the created ItemStack with the gate type identifier
     private ItemStack createGUIItem(ConfigurationSection itemSection, Material material, GateType type) {
         ItemStack item = createConfiguredItem(itemSection, material);
         ItemMeta meta = item.getItemMeta();
@@ -304,6 +328,10 @@ public class LogicGatesCommand implements CommandExecutor {
         player.sendMessage(plugin.getMessage("rotate_wand_received"));
     }
 
+    /// Creates a new rotation wand ItemStack. The rotation wand is a stick with a unique custom model data value,
+    /// display name, lore, and is unbreakable.
+    ///
+    /// @return the created rotation wand ItemStack
     private ItemStack createRotationWand() {
         ItemStack wand = new ItemStack(Material.STICK);
         ItemMeta meta = wand.getItemMeta();
@@ -317,6 +345,11 @@ public class LogicGatesCommand implements CommandExecutor {
 
     //endregion
 
+    /// Checks if the given ItemStack is a rotation wand. A rotation wand is identified by being a stick
+    /// with a specific custom model data value.
+    ///
+    /// @param item the ItemStack to check
+    /// @return true if the item is a rotation wand, false otherwise
     public boolean isRotationWand(ItemStack item) {
         if (item == null || item.getType() != Material.STICK) return false;
         ItemMeta meta = item.getItemMeta();

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/integrations/WorldEditIntegration.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/integrations/WorldEditIntegration.java
@@ -27,7 +27,6 @@ import org.bukkit.inventory.meta.BookMeta;
 import pl.bednarskiwsieci.logicgatesplugin.LogicGatesPlugin;
 import pl.bednarskiwsieci.logicgatesplugin.model.GateData;
 import pl.bednarskiwsieci.logicgatesplugin.model.GateType;
-import pl.bednarskiwsieci.logicgatesplugin.util.GateUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
@@ -53,12 +53,10 @@ public class GateListener implements Listener {
         this.updateChecker = updateChecker;
     }
 
-    /**
-     * Determines the direction a player is facing based on their yaw.
-     *
-     * @param player the player whose facing direction is to be determined.
-     * @return the BlockFace direction the player is facing (NORTH, EAST, SOUTH, or WEST).
-     */
+    /// Determines the direction a player is facing based on their yaw.
+    ///
+    /// @param player the player whose facing direction is to be determined.
+    /// @return the BlockFace direction the player is facing (NORTH, EAST, SOUTH, or WEST).
     public static BlockFace getPlayerFacingDirection(Player player) {
         float yaw = player.getLocation().getYaw();
 

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/listeners/GateListener.java
@@ -53,6 +53,12 @@ public class GateListener implements Listener {
         this.updateChecker = updateChecker;
     }
 
+    /**
+     * Determines the direction a player is facing based on their yaw.
+     *
+     * @param player the player whose facing direction is to be determined.
+     * @return the BlockFace direction the player is facing (NORTH, EAST, SOUTH, or WEST).
+     */
     public static BlockFace getPlayerFacingDirection(Player player) {
         float yaw = player.getLocation().getYaw();
 
@@ -446,6 +452,9 @@ public class GateListener implements Listener {
         }
     }
 
+    /// Handles the InventoryClickEvent to manage interactions with a custom GUI.
+    ///
+    /// @param event the InventoryClickEvent triggered when a player clicks in an inventory.
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         if (!(event.getWhoClicked() instanceof Player player)) return;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateData.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateData.java
@@ -52,9 +52,7 @@ public class GateData {
         this.interval = interval;
     }
 
-    public boolean isThreeInput() {
-        return isThreeInput;
-    }
+    public boolean isThreeInput() { return isThreeInput; }
 
     public void setThreeInput(boolean threeInput) {
         isThreeInput = threeInput;

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateType.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/model/GateType.java
@@ -1,5 +1,56 @@
 package pl.bednarskiwsieci.logicgatesplugin.model;
 
+/**
+ * Enumeration representing different types of logic gates.
+ */
 public enum GateType {
-    XOR, AND, OR, NOT, NAND, NOR, XNOR, IMPLICATION, RS_LATCH, TIMER
+    /**
+     * Exclusive OR gate.
+     */
+    XOR,
+
+    /**
+     * AND gate.
+     */
+    AND,
+
+    /**
+     * OR gate.
+     */
+    OR,
+
+    /**
+     * NOT gate (inverter).
+     */
+    NOT,
+
+    /**
+     * NAND gate (NOT AND).
+     */
+    NAND,
+
+    /**
+     * NOR gate (NOT OR).
+     */
+    NOR,
+
+    /**
+     * Exclusive NOR gate.
+     */
+    XNOR,
+
+    /**
+     * Implication gate.
+     */
+    IMPLICATION,
+
+    /**
+     * RS Latch.
+     */
+    RS_LATCH,
+
+    /**
+     * Timer gate.
+     */
+    TIMER
 }

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/ConfigManager.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/ConfigManager.java
@@ -19,6 +19,7 @@ public class ConfigManager {
     public static final String CONFIG_LANGUAGE = "language";
     public static final String CONFIG_LEGACY_MODE = "legacyMode";
     public static final String CONFIG_NOT_GATE_INPUT_POSITION = "notGateInputPosition";
+    public static final String CONFIG_ONE_TICK = "oneTick";
 
     private final LogicGatesPlugin plugin;
     private File configFile;
@@ -61,6 +62,7 @@ public class ConfigManager {
         plugin.setDefaultLang(config.getString(CONFIG_LANGUAGE, "en"));
         plugin.setLegacyMode(config.getBoolean(CONFIG_LEGACY_MODE, false));
         plugin.setNotGateInputPosition(config.getString(CONFIG_NOT_GATE_INPUT_POSITION, "default"));
+        plugin.setOneTick(config.getBoolean(CONFIG_ONE_TICK, false));
     }
 
     /// Reloads configuration from disk
@@ -83,6 +85,7 @@ public class ConfigManager {
             diskConfig.set(CONFIG_LANGUAGE, plugin.getDefaultLang());
             diskConfig.set(CONFIG_LEGACY_MODE, plugin.isLegacyMode());
             diskConfig.set(CONFIG_NOT_GATE_INPUT_POSITION, plugin.getNotGateInputPosition());
+            diskConfig.set(CONFIG_ONE_TICK, plugin.isOneTick());
 
             diskConfig.save(configFile);
         } catch (IOException e) {

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GateUtils.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GateUtils.java
@@ -96,7 +96,7 @@ public final class GateUtils {
             case XOR -> {
                 if (isThreeInput) {
                     int count = (input1 ? 1 : 0) + (input2 ? 1 : 0) + (input3 ? 1 : 0);
-                    yield count % 2 == 1;
+                    yield (count & 1) == 1;
                 } else {
                     yield input1 != input2;
                 }

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GatesConfigManager.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/GatesConfigManager.java
@@ -28,6 +28,7 @@ public class GatesConfigManager {
         initializeGatesFile();
     }
 
+    /// Initializes the gates file. If the file doesn't exist, it creates a new one.
     private void initializeGatesFile() {
         gatesFile = new File(plugin.getDataFolder(), GATES_FILE_NAME);
 
@@ -41,6 +42,9 @@ public class GatesConfigManager {
         }
     }
 
+    /// Saves the current state of gates to the gates file.
+    ///
+    /// @param gates a ConcurrentHashMap containing the locations and data of the gates to be saved.
     public void saveGates(ConcurrentHashMap<Location, GateData> gates) {
         Map<String, GateData> serializableGates = new HashMap<>();
 
@@ -55,6 +59,9 @@ public class GatesConfigManager {
         }
     }
 
+    /// Loads the gates from the gates file into the provided ConcurrentHashMap.
+    ///
+    /// @param gates a ConcurrentHashMap that will be populated with the loaded gates.
     public void loadGates(ConcurrentHashMap<Location, GateData> gates) {
         try (FileReader reader = new FileReader(gatesFile)) {
             Map<String, GateData> serializedGates = gson.fromJson(reader,

--- a/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/UpdateChecker.java
+++ b/src/main/java/pl/bednarskiwsieci/logicgatesplugin/util/UpdateChecker.java
@@ -21,6 +21,7 @@ public class UpdateChecker {
     private static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
+
     // GitHub repository details (CHANGE THESE)
     private static final String GITHUB_USER = "piotrmaciejbednarski";
     private static final String REPO_NAME = "LogicGates";
@@ -129,6 +130,9 @@ public class UpdateChecker {
         return latestParts.length > currentParts.length;
     }
 
+    /// Sends an update message to the specified receiver.
+    ///
+    /// @param receiver the command sender who will receive the update message.
     public void sendUpdateMessage(CommandSender receiver) {
         String message = plugin.getMessage("update_checker.available",
                 latestVersion, plugin.getDescription().getVersion());
@@ -148,10 +152,16 @@ public class UpdateChecker {
                 TimeUnit.HOURS.toMillis(checkInterval);
     }
 
+    /// Gets the latest available version of the plugin.
+    ///
+    /// @return a string representing the latest version.
     public String getLatestVersion() {
         return this.latestVersion;
     }
 
+    /// Gets the download URL for the latest version of the plugin.
+    ///
+    /// @return a string representing the download URL.
     public String getDownloadUrl() {
         return String.format("https://github.com/%s/%s/releases/latest",
                 GITHUB_USER,


### PR DESCRIPTION
Using the `oneTick` config setting you can specify whether the gateway should update every default 2 ticks (more stable) or 1 tick (faster).

Improved documentation for many methods.